### PR TITLE
Fixed problem with locale don't specified into config file

### DIFF
--- a/src/SeoTools.php
+++ b/src/SeoTools.php
@@ -11,8 +11,8 @@ class SeoTools
 	{
 		$seo = config('laravel-seo');
 		$route_name = Route::current()->getName();
-		$locale = $locale = \App::getLocale();
-
+		$locale = \App::getLocale();
+	
 		$seo_route = [
 			'title' => '',
 			'description' => '',
@@ -48,9 +48,38 @@ class SeoTools
 				$seo_route['image_w'] = isset($s['image_w']) ? $s['image_w'] : $seo_route['image_w'];
 				$seo_route['image_h'] = isset($s['image_h']) ? $s['image_h'] : $seo_route['image_h'];
 			}
+			$result = $seo[$locale]['global'];
+		}
+		else
+		{
+			if(isset($seo['global']))
+			{
+				$seo_route = [
+					'title' => isset($seo['global']['title']) ? $seo['global']['title'] : '',
+					'description' => isset($seo['global']['description']) ? $seo['global']['description'] : '',
+					'keywords' => isset($seo['global']['keywords']) ? $seo['global']['keywords'] : '',
+					'image' => isset($seo['global']['image']) ? $seo['global']['image'] : '',
+					'image_w' => isset($seo['global']['image_w']) ? $seo['global']['image_w'] : '',
+					'image_h' => isset($seo['global']['image_h']) ? $seo['global']['image_h'] : '',
+					'breadcrumb' => [],
+				];
+			}
+			if(isset($seo['routes'][$route_name]))
+			{
+				$s = $seo['routes'][$route_name];
+				$seo_route['title'] = isset($s['title']) ? $s['title'] : $seo_route['title'];
+				$seo_route['description'] = isset($s['description']) ? $s['description'] : $seo_route['description'];
+				$seo_route['keywords'] = isset($s['keywords']) ? $s['keywords'] : $seo_route['keywords'];
+				$seo_route['breadcrumb'] = isset($s['breadcrumb']) ? $s['breadcrumb'] : $seo_route['breadcrumb'];
+				$seo_route['image'] = isset($s['image']) ? $s['image'] : $seo_route['image'];
+				$seo_route['image_w'] = isset($s['image_w']) ? $s['image_w'] : $seo_route['image_w'];
+				$seo_route['image_h'] = isset($s['image_h']) ? $s['image_h'] : $seo_route['image_h'];
+			}
+			$result = $seo['global'];
+
 		}
 
-		$result = $seo[$locale]['global'];
+		
 		$result['route'] = $seo_route;
 		return $result;
 	}


### PR DESCRIPTION
Hi!, I modified the code into **SeoTools.php**, this is because when I install your package into my project using your config file example, the app show me a error:

> ErrorException in SeoTools.php line 53: Undefined index: es

This is because the config file example, dont have specified es or en (locale), this have directly global

```

return [
    'global' => [
```

so for that this work fine in my case I modified the config file, I added:

```
return [
    'es' => [
        'global' => [
```

**es** in my case because my website is in **spanish**, in this commit I modified not the config file, because I think that is important have the code multilanguage, so I verified if exist locale kay in config file, before use _$seo[$locale]['global']_ directly

```
if(isset($seo[$locale]))
{
    if(isset($seo[$locale]['global']))
    {
```

I hope you merge this fix of if you have a better solution for this problem ;) :D
